### PR TITLE
Docker-Compose for running mysql container.

### DIFF
--- a/Docker-Compose/mysql8/README.md
+++ b/Docker-Compose/mysql8/README.md
@@ -1,0 +1,12 @@
+A single docker-compose container to run mysql.
+
+(1) mysql 8.0 (Ubuntu 16.04.01)
+
+docker-compose.yml file uses an .env file to populate the db users and password.  The .env file has not been added to the repo for obvious reasons.
+
+example: .env
+
+MYSQL_ROOT_PSWD=password
+MYSQL_USER=mysql_user
+MYSQL_USER_PSWD=user_password
+MYSQL_DATABASE=userdb

--- a/Docker-Compose/mysql8/docker-compose.yml
+++ b/Docker-Compose/mysql8/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.1"
+services:
+
+    mysql:
+      volumes:
+        - ./mysql:/mysql
+        - ./mysql/mysqldump:/docker-entrypoint-initdb.d
+        - mysql-data:/var/lib/mysql
+      image: mysql:8.0
+      container_name: mysql8
+      working_dir: /mysql
+      environment:
+        - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PSWD}
+        - MYSQL_USER=${MYSQL_USER}
+        - MYSQL_PASSWORD=${MYSQL_USER_PSWD}
+        - MYSQL_PORT=3306
+        - MYSQL_DATABASE=${MYSQL_DATABASE}
+      #ports:
+      #  - "9002:3306"
+      networks:
+        - mysql-backend
+
+networks:
+  mysql-backend:
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
Includes a consistent volume.
Includes a placeholder example_mysqldump.sql to populate db upon creation of db.